### PR TITLE
Flytte valideringslogikken til river-valideringen

### DIFF
--- a/app/src/main/kotlin/no/nav/tms/utkast/UtkastUpdatedSink.kt
+++ b/app/src/main/kotlin/no/nav/tms/utkast/UtkastUpdatedSink.kt
@@ -1,11 +1,14 @@
 package no.nav.tms.utkast
 
-import com.fasterxml.jackson.databind.JsonNode
 import mu.KotlinLogging
-import no.nav.helse.rapids_rivers.*
-import no.nav.tms.utkast.builder.UtkastValidator
+import no.nav.helse.rapids_rivers.JsonMessage
+import no.nav.helse.rapids_rivers.MessageContext
+import no.nav.helse.rapids_rivers.MessageProblems
+import no.nav.helse.rapids_rivers.RapidsConnection
+import no.nav.helse.rapids_rivers.River
+import no.nav.tms.utkast.builder.UtkastValidator.validateLink
+import no.nav.tms.utkast.builder.UtkastValidator.validateTittel
 import no.nav.tms.utkast.config.JsonMessageHelper.keepFields
-import no.nav.tms.utkast.config.JsonNodeHelper.checkForProblems
 import no.nav.tms.utkast.database.UtkastRepository
 
 class UtkastUpdatedSink(
@@ -21,60 +24,29 @@ class UtkastUpdatedSink(
         River(rapidsConnection).apply {
             validate { it.demandValue("@event_name", "updated") }
             validate { it.requireKey("utkastId") }
-            validate { it.interestedIn("tittel", "link", "tittel_i18n") }
+            validate {
+                it.interestedIn("link") { jsonNode -> validateLink(jsonNode.textValue()) }
+                it.interestedIn("tittel") { jsonNode -> validateTittel(jsonNode.textValue()) }
+                it.interestedIn("tittel_i18n") { languages ->
+                    languages.forEach { title -> validateTittel(title.textValue()) }
+                }
+            }
         }.register(this)
     }
 
     override fun onPacket(packet: JsonMessage, context: MessageContext) {
-
         val utkastId = packet["utkastId"].asText()
 
-        packet.keepFields("tittel_i18n")
-            .takeIf { !it.isEmpty }
-            ?.validate()
-            ?.get("tittel_i18n")
-            ?.toString()
-            ?.let { utkastRepository.updateUtkastI18n(utkastId, it) }
+        if(!packet["tittel_i18n"].isEmpty) utkastRepository.updateUtkastI18n(utkastId, packet["tittel_i18n"].toString())
 
         packet.keepFields("tittel", "link")
-            .validate()
             .toString()
             .let { utkastRepository.updateUtkast(utkastId, it) }
 
         rapidMetricsProbe.countUtkastChanged("updated")
     }
 
-    private fun JsonNode.validate(): JsonNode {
-
-        val potentialProblems = listOf(
-            checkForProblems("tittel", UtkastValidator::validateTittel),
-            checkForProblems("tittel_i18n", UtkastValidator::validateTittel),
-            checkForProblems("link", UtkastValidator::validateLink)
-        )
-
-        handleProblems(potentialProblems)
-
-        return this
-    }
-
-    private fun handleProblems(potentialProblems: List<String?>) {
-        val problems = potentialProblems.filterNotNull()
-            .takeIf { it.isNotEmpty() }
-
-        if (problems != null) {
-            val messageProblems = MessageProblems("Feil ved validering av utkast opprettet.")
-
-            problems.forEach {
-                messageProblems.severe(it)
-            }
-
-            throw MessageProblems.MessageException(messageProblems)
-        }
-    }
-
-    override fun onSevere(error: MessageProblems.MessageException, context: MessageContext) {
-        log.info("Valideringsfeil ved oppdatering av utkast", error)
+    override fun onError(problems: MessageProblems, context: MessageContext) {
+        log.info(problems.toString())
     }
 }
-
-

--- a/app/src/main/kotlin/no/nav/tms/utkast/UtkastUpdatedSink.kt
+++ b/app/src/main/kotlin/no/nav/tms/utkast/UtkastUpdatedSink.kt
@@ -37,7 +37,9 @@ class UtkastUpdatedSink(
     override fun onPacket(packet: JsonMessage, context: MessageContext) {
         val utkastId = packet["utkastId"].asText()
 
-        if(!packet["tittel_i18n"].isEmpty) utkastRepository.updateUtkastI18n(utkastId, packet["tittel_i18n"].toString())
+        packet["tittel_i18n"].takeIf { !it.isEmpty }
+            ?.toString()
+            ?.let { utkastRepository.updateUtkastI18n(utkastId, it) }
 
         packet.keepFields("tittel", "link")
             .toString()


### PR DESCRIPTION
Eksempelloggin hvis to ting er feil:

"E: Required utkastId did not match the predicate: Feltet `utkastId` må enten være UUID eller ULID.\nE: Required ident did not match the predicate: Feltet `ident` kan ikke overskride 11 tegn."